### PR TITLE
Poetry

### DIFF
--- a/.fleet/run.json
+++ b/.fleet/run.json
@@ -3,15 +3,14 @@
         {
             "type": "command",
             "name": "Rebuild",
-            "program": "mkdocs",
-            "args": ["build"],
+            "program": "poetry",
+            "args": ["run", "mkdocs", "build"],
         },
         {
             "type": "command",
             "name": "Serve",
-            "program": "mkdocs",
-            "args": ["serve"],
+            "program": "poetry",
+            "args": ["run", "mkdocs", "serve"],
         },
-        
     ]
 }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,16 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install mkdocs markdown-callouts mkdocs-autorefs mkdocs-include-dir-to-nav mkdocs-material pymdown-extensions
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2
+
       - name: Build
-        run: mkdocs build
+        run: poetry run mkdocs build
+
       - name: Publish
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/README.md
+++ b/README.md
@@ -1,25 +1,20 @@
 # docs
 
-It is documentation repository for the projects of [InsanusMokrassar](https://github.com/InsanusMokrassar). In case you wish to interact with that lib localy, you will need to install dependnecies and mkdocs:
+It is a documentation repository for the projects of [InsanusMokrassar](https://github.com/InsanusMokrassar).
+
+## Running locally
+
+For the ease of dependencies management, this repository uses [Poetry](https://python-poetry.org), a Python project & dependencies manager.
+In case you wish to interact with these docs locally, make sure to [install](https://python-poetry.org/docs/#installation) it first.
+
+In `Fleet` you may use [these configs](https://github.com/InsanusMokrassar/docs/blob/master/.fleet/run.json) to work with the repo.
+
+To build or run it in vanilla terminal, use the following commands:
 
 ```bash
-pip install mkdocs markdown-callouts mkdocs-autorefs mkdocs-include-dir-to-nav mkdocs-material pymdown-extensions
+poetry run mkdocs build # Just build the site
 ```
-
-**The snippet above can be outdated. See [publish workflow](https://github.com/InsanusMokrassar/docs/blob/master/.github/workflows/publish.yml) to be sure about building steps**
-
-## Running and build
-
-In `Fleet` you may use [these configs](https://github.com/InsanusMokrassar/docs/blob/master/.fleet/run.json). Localy there are several common options for build:
 
 ```bash
-mkdocs build
+poetry run mkdocs serve # Run a local server with the site
 ```
-
-^ Will build mkdocs
-
-```bash
-mkdocs serve
-```
-
-^ Will continuously build __until first failure in build__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Documentation for InsanusMokrassar's projects"
 authors = ["InsanusMokrassar"]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "3.8.10"
 mkdocs = "^1.4.3"
 markdown-callouts = "^0.3.0"
 mkdocs-autorefs = "^0.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "docs"
+version = "1.0.0"
+description = "Documentation for InsanusMokrassar's projects"
+authors = ["InsanusMokrassar"]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+mkdocs = "^1.4.3"
+markdown-callouts = "^0.3.0"
+mkdocs-autorefs = "^0.4.1"
+mkdocs-include-dir-to-nav = "^1.2.0"
+mkdocs-material = "^9.1.15"
+pymdown-extensions = "^10.0.1"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
I propose to use [Poetry](https://python-poetry.org) to manage Python dependencies. It's like Gradle in the Python world.

### Pros

- Unified dependencies management. Both GitHub Actions and CLI could benefit from it.
- No need to use `pip install` / `dependencies.txt`. `poetry run` will always ensure the deps are installed.
- Poetry will automagically [create a virtual env beneath](https://python-poetry.org/docs/basic-usage/#using-your-virtual-environment). So that no other Python installations (global or condas or whatever Python would be first in the `PATH`) would be polluted by the required libraties. The v-env is unique to the project and is completely opaque to the user.

### Cons

- Requires users to install Poetry.

I am not sure what Fleet is, so I didn't touch its scripts, but I'm pretty much sure it could use `poetry run` as well